### PR TITLE
fix: always return list of metrics exposed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: build
+
 REGISTRY=semaphoreci/metrics-apiserver
 LATEST_VERSION=$(shell git tag | sort --version-sort | tail -n 1)
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -133,10 +133,9 @@ func (p *SemaphoreMetricsProvider) GetExternalMetric(ctx context.Context, namesp
 func (p *SemaphoreMetricsProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {
 	list := []provider.ExternalMetricInfo{}
 
-	p.data.Range(func(key, value any) bool {
-		list = append(list, provider.ExternalMetricInfo{Metric: key.(string)})
-		return true
-	})
+	for _, m := range AllMetrics {
+		list = append(list, provider.ExternalMetricInfo{Metric: m})
+	}
 
 	return list
 }


### PR DESCRIPTION
We only return the list of metrics exposed in the `/apis/external.metrics.k8s.io/v1beta1` endpoint if we have gathered some metrics (an agent type pool has been deployed with autoscaling). That can lead to warning messages like `Got empty response for: external.metrics.k8s.io/v1beta1` when installing agent charts. We should always return the list of metrics exposed instead.